### PR TITLE
Fix partially hardcoded XDG_RUNTIME_DIR

### DIFF
--- a/client.go
+++ b/client.go
@@ -35,12 +35,12 @@ import (
 
 const version = 32
 
-func defaultAddr() (string, error) {
+func defaultAddr() string {
 	runDir, ok := os.LookupEnv("XDG_RUNTIME_DIR")
 	if !ok {
-		return "", fmt.Errorf("XDG_RUNTIME_DIR must be defined")
+		runDir = fmt.Sprintf("/run/user/%d", os.Getuid())
 	}
-	return fmt.Sprintf("%s/pulse/native", runDir), nil
+	return fmt.Sprintf("%s/pulse/native", runDir)
 }
 
 type packetResponse struct {
@@ -73,10 +73,7 @@ type Client struct {
 // NewClient establishes a connection to the PulseAudio server.
 func NewClient(addressArr ...string) (*Client, error) {
 	if len(addressArr) < 1 {
-		addr, err := defaultAddr()
-		if err != nil {
-			return nil, fmt.Errorf("no addresses to try: %v", err)
-		}
+		addr := defaultAddr()
 		addressArr = []string{addr}
 	}
 

--- a/client.go
+++ b/client.go
@@ -35,14 +35,6 @@ import (
 
 const version = 32
 
-func defaultAddr() string {
-	runDir, ok := os.LookupEnv("XDG_RUNTIME_DIR")
-	if !ok {
-		runDir = fmt.Sprintf("/run/user/%d", os.Getuid())
-	}
-	return fmt.Sprintf("%s/pulse/native", runDir)
-}
-
 type packetResponse struct {
 	buff *bytes.Buffer
 	err  error
@@ -73,8 +65,11 @@ type Client struct {
 // NewClient establishes a connection to the PulseAudio server.
 func NewClient(addressArr ...string) (*Client, error) {
 	if len(addressArr) < 1 {
-		addr := defaultAddr()
-		addressArr = []string{addr}
+		xdgRuntimeDir, ok := os.LookupEnv("XDG_RUNTIME_DIR")
+		if !ok {
+			xdgRuntimeDir = fmt.Sprintf("/run/user/%d", os.Getuid())
+		}
+		addressArr = []string{fmt.Sprintf("%s/pulse/native", xdgRuntimeDir)}
 	}
 
 	conn, err := net.Dial("unix", addressArr[0])


### PR DESCRIPTION
XDG_RUNTIME_DIR may be in a different path to the one previously
hardcoded, in which case connecting fails with:

    Error: dial unix /run/user/1000/pulse/native: connect: no such file or directory

Read the value at runtime instead.
